### PR TITLE
Deleting looker view before recreating to avoid manual refresh

### DIFF
--- a/elt_chess_games/assets/looker.py
+++ b/elt_chess_games/assets/looker.py
@@ -33,6 +33,8 @@ def bigquery_view_monthly_summary(bigquery: BigQueryResource):
     view.mview_query = formatted_query
 
     with bigquery.get_client() as client:
-        # Make an API request to create the materialized view.
+        # Base tables fully refresh so delete materialised view and recreate it
+        
+        client.delete_table(view_id)
         view = client.create_table(view, exists_ok=True)
         print(f"Created {view.table_type}: {str(view.reference)}")


### PR DESCRIPTION
Materialised Views in BigQuery require you to delete and recreate the MV if the base tables are also recreated. Since our dbt models that create the base tables are being materialised as tables, we recreate these base tables.

We thus add a feature to delete the MV before creating it using the latest partition.